### PR TITLE
Add ability to reference another server section

### DIFF
--- a/src/montague/loadwsgi.py
+++ b/src/montague/loadwsgi.py
@@ -183,6 +183,11 @@ class Loader(object):
 
     def load_server(self, name=None):
         server_config = self.server_config(name)
+
+        # name with no colon => load server from a different named section
+        if ':' not in server_config.config['use']:
+            return self.load_server(server_config.config['use'])
+
         scheme, resource = server_config.config['use'].split(':', 1)
         if scheme in ('egg', 'package'):
             factory = self._load_entry_point_factory(

--- a/tests/config_files/server_reference_another_section.ini
+++ b/tests/config_files/server_reference_another_section.ini
@@ -1,0 +1,37 @@
+[DEFAULT]
+foo = bar
+
+[application:main]
+use = package:FakeApp#basic_app
+
+[application:egg]
+use = egg:FakeApp#other
+
+[server:server_factory]
+use = egg:FakeApp#server_factory
+port = 42
+
+[server:main]
+use = server_factory
+
+[server:reference_non_existing_section]
+use = section_that_doesnt_exist
+
+[server:server_runner]
+use = egg:FakeApp#server_runner
+host = 127.0.0.1
+
+[filter:filter]
+use = egg:FakeApp#caps
+method_to_call = lower
+
+[app:filtered-app]
+use = package:FakeApp#basic_app
+filter-with = filter
+
+[filter:filter1]
+use = egg:FakeApp#caps
+filter-with = filter2
+
+[filter:filter2]
+use = egg:FakeApp#caps

--- a/tests/test_ini_handling.py
+++ b/tests/test_ini_handling.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from montague.ini import IniConfigLoader
 from montague.loadwsgi import Loader
 from montague import load_app, load_server, load_filter
@@ -73,6 +74,21 @@ def test_load_server(fakeapp):
     assert actual.montague_conf['local_conf']['host'] == '127.0.0.1'
     resp = actual.get('/')
     assert b'This is basic app2' == resp.body
+
+
+def test_load_server_reference_another_section(fakeapp):
+    config_path = os.path.join(here, 'config_files/server_reference_another_section.ini')
+    server = load_server(config_path, name=DEFAULT)
+    actual = server(fakeapp.apps.basic_app)
+    assert actual.montague_conf['local_conf']['port'] == '42'
+    resp = actual.get('/')
+    assert b'This is basic app' == resp.body
+
+
+def test_load_server_reference_another_section(fakeapp):
+    config_path = os.path.join(here, 'config_files/server_reference_another_section.ini')
+    with pytest.raises(KeyError) as excinfo:
+        server = load_server(config_path, name='reference_non_existing_section')
 
 
 def test_load_filter(fakeapp):


### PR DESCRIPTION
E.g.:

    [server:waitress]
    use = egg:waitress#main
    host = 0.0.0.0
    port = 9600

    [server:main]
    use = waitress

This works in PasteDeploy ([doc link](http://pythonpaste.org/deploy/#applications)) but had been failing in montague with:

      File "/Users/marca/dev/git-repos/montague/src/montague/compat/loadwsgi.py", line 321, in loadserver
        return loader.load_server(name)
      File "/Users/marca/dev/git-repos/montague/src/montague/loadwsgi.py", line 187, in load_server
        scheme, resource = server_config.config['use'].split(':', 1)
    ValueError: need more than 1 value to unpack

This change adds support for it.

Cc: @inklesspen, @sontek, @sudarkoff