### PR TITLE
Allow app name to default to 'main' in `use egg:module`

### DIFF
--- a/src/montague/loadwsgi.py
+++ b/src/montague/loadwsgi.py
@@ -98,7 +98,10 @@ class Loader(object):
         return factory
 
     def _load_entry_point_factory(self, resource, entry_point_groups):
-        pkg, name = resource.split('#')
+        if '#' in resource:
+            pkg, name = resource.split('#')
+        else:
+            pkg, name = resource, 'main'
         entry_point_map = pkg_resources.get_entry_map(pkg)
         factory = None
         for group in entry_point_groups:

--- a/tests/compat/sample_configs/basic_app.ini
+++ b/tests/compat/sample_configs/basic_app.ini
@@ -4,6 +4,9 @@ use = egg:FakeApp#basic_app
 [application:other]
 use = egg:FakeApp#other
 
+[application:no_app_name]
+use = egg:FakeApp
+
 [composit:remote_addr]
 use = egg:FakeApp#remote_addr
 app.1 = main

--- a/tests/compat/test_basic_app.py
+++ b/tests/compat/test_basic_app.py
@@ -19,6 +19,12 @@ def test_main(fakeapp):
     assert app is fakeapp.apps.basic_app
 
 
+def test_no_app_name(fakeapp):
+    app = loadapp('config:sample_configs/basic_app.ini#no_app_name',
+                  relative_to=here)
+    assert app is fakeapp.apps.basic_app
+
+
 def test_other(fakeapp):
     app = loadapp('config:sample_configs/basic_app.ini#other',
                   relative_to=here)

--- a/tests/fake_packages/FakeApp.egg/FakeApp.egg-info-dir/entry_points.txt
+++ b/tests/fake_packages/FakeApp.egg/FakeApp.egg-info-dir/entry_points.txt
@@ -1,6 +1,7 @@
 [paste.app_factory]
 
       basic_app=fakeapp.apps:make_basic_app
+      main=fakeapp.apps:make_basic_app
       other=fakeapp.apps:make_basic_app2
       configed=fakeapp.configapps:SimpleApp.make_app
       

--- a/tests/fake_packages/FakeApp.egg/setup.py
+++ b/tests/fake_packages/FakeApp.egg/setup.py
@@ -7,6 +7,7 @@ setup(
     entry_points={
       'paste.app_factory': """
       basic_app=fakeapp.apps:make_basic_app
+      main=fakeapp.apps:make_basic_app
       other=fakeapp.apps:make_basic_app2
       configed=fakeapp.configapps:SimpleApp.make_app
       """,


### PR DESCRIPTION
Allows:

    [app:main]
    use = egg:inventorysvc

and the `#main` part is inferred, as PasteDeploy does.

Cc: @inklesspen, @sontek, @sudarkoff