### PR TITLE
Fix some eval-related bugs in the logging ini conversion.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 
 * Remove the PasteDeploy FakeApp package in favor of ``montague_testapps``.
 * Enable a ``looponfail`` tox environment.
+* Fix some eval-related bugs in the logging ini conversion.
 
 0.1.5 (2015-05-12)
 -----------------------------------------

--- a/tests/config_files/logging.ini
+++ b/tests/config_files/logging.ini
@@ -2,7 +2,7 @@
 keys=root,simpleEx
 
 [handlers]
-keys=console
+keys=console,syslog
 
 [formatters]
 keys=simple,complicated,withclass
@@ -22,6 +22,11 @@ class=StreamHandler
 level=DEBUG
 formatter=simple
 args=(sys.stdout,)
+
+[handler_syslog]
+class=handlers.SysLogHandler
+level=WARNING
+formatter=complicated
 
 [formatter_simple]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/tests/test_ini_handling.py
+++ b/tests/test_ini_handling.py
@@ -140,6 +140,11 @@ def test_logging_config():
                 'level': 'DEBUG',
                 'formatter': 'simple',
                 stream_key_name: sys.stdout,
+            },
+            'syslog': {
+                'class': 'logging.handlers.SysLogHandler',
+                'level': 'WARNING',
+                'formatter': 'complicated',
             }
         },
         'formatters': {

--- a/tests/test_logging_conversion.py
+++ b/tests/test_logging_conversion.py
@@ -41,6 +41,11 @@ def test_handlers(ini_cp):
             'level': 'DEBUG',
             'formatter': 'simple',
             stream_key_name: sys.stdout,
+        },
+        'syslog': {
+            'class': 'logging.handlers.SysLogHandler',
+            'level': 'WARNING',
+            'formatter': 'complicated',
         }
     }
     actual = convert_handlers(ini_cp)


### PR DESCRIPTION
The handler classes might be multi-dotted; it's simplest to find that via eval instead of hasattr, like logging.config does. Also, if args wasn't specified, it should use a default empty tuple instead of reusing the value from the last handler!