### PR TITLE
Logging config is included in the MSF config.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,10 @@ unreleased
 
 * Remove the PasteDeploy FakeApp package in favor of ``montague_testapps``.
 * Enable a ``looponfail`` tox environment.
-* Fix some eval-related bugs in the logging ini conversion.
+* Add logging ini conversion
 * Reincorporate the test JSON config loader, active only during tests.
 * Remove the ``DEFAULT`` sentinal value; we'll use 'main' as the default loadable name, just like grandpa used to do. This is a breaking change.
+* Add logging config to the Montague Standard Format.
 
 0.1.5 (2015-05-12)
 -----------------------------------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -37,6 +37,7 @@ return a dict that looks like this: ::
         "composite": {},
         "filter": {},
         "server": {},
+        "logging": {},
     }
 
 Of course, the dict can contain other keys as well, but those are the

--- a/src/montague/loadwsgi.py
+++ b/src/montague/loadwsgi.py
@@ -256,7 +256,10 @@ class Loader(object):
     def logging_config(self, name=None):
         if name is None:
             name = 'main'
-        return self.config_loader.logging_config(name)
+        try:
+            return self.config_loader.logging_config(name)
+        except NotImplementedError:
+            return self.config['logging'][name]
 
 
 def _get_suffix(path):

--- a/src/montague/testjson.py
+++ b/src/montague/testjson.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import json
-import six
 from montague.interfaces import IConfigLoader, IConfigLoaderFactory
 from montague.structs import LoadableConfig
 from zope.interface import directlyProvides, implementer
@@ -24,10 +23,7 @@ class JSONConfigLoader(object):
         return json.load(open(self.path))
 
     def config(self):
-        config = {}
-        for section, vals in six.iteritems(self._config):
-            config[section] = vals
-        return config
+        return self._config
 
     def app_config(self, name):
         # Obviously this will throw a KeyError if the config isn't there.
@@ -41,4 +37,8 @@ class JSONConfigLoader(object):
 
     def filter_config(self, name):
         # Not covered in tests yet.
+        raise NotImplementedError
+
+    def logging_config(self, name):
+        # montague should be able to load it from the .config() property.
         raise NotImplementedError

--- a/tests/config_files/simple_config.json
+++ b/tests/config_files/simple_config.json
@@ -26,5 +26,39 @@
             "use": "egg:montague_testapps#caps",
             "method_to_call": "lower"
         }
+    },
+    "logging": {
+        "main": {
+            "version": 1,
+            "root": {
+                "handlers": [
+                    "console"
+                ],
+                "level": "INFO"
+            },
+            "loggers": {
+                "mimir": {
+                    "handlers": [],
+                    "level": "DEBUG"
+                },
+                "sqlalchemy.engine": {
+                    "handlers": [],
+                    "level": "INFO"
+                }
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "generic",
+                    "level": "NOTSET",
+                    "stream": "ext://sys.stderr"
+                }
+            },
+            "formatters": {
+                "generic": {
+                    "format": "%(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s"
+                }
+            }
+        }
     }
 }

--- a/tests/test_json_handling.py
+++ b/tests/test_json_handling.py
@@ -38,6 +38,30 @@ def working_set():
     patcher.stop()
 
 
+LOGGING_CONFIG = {
+    u'loggers': {
+        u'sqlalchemy.engine': {u'handlers': [], u'level': u'INFO'},
+        u'mimir': {u'handlers': [], u'level': u'DEBUG'}
+    },
+    u'version': 1,
+    u'root': {
+        u'handlers': [u'console'],
+        u'level': u'INFO'
+    },
+    u'formatters': {
+        u'generic': {u'format': u'%(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s'}
+    },
+    u'handlers': {
+        u'console': {
+            u'formatter': u'generic',
+            u'class': u'logging.StreamHandler',
+            u'stream': u'ext://sys.stderr',
+            u'level': u'NOTSET'
+        }
+    }
+}
+
+
 def test_read_config(working_set):
     expected = {
         'application': {
@@ -64,6 +88,7 @@ def test_read_config(working_set):
                 'host': '127.0.0.1',
             },
         },
+        'logging': {'main': LOGGING_CONFIG},
     }
     json_style_loader = Loader(os.path.join(here, 'config_files/simple_config.json'))
 
@@ -98,3 +123,10 @@ def test_load_filtered_app(working_set):
     assert isinstance(app, montague_testapps.apps.CapFilter)
     assert app.app is montague_testapps.apps.basic_app
     assert app.method_to_call == 'lower'
+
+
+def test_load_logging_config(working_set):
+    config_path = os.path.join(here, 'config_files/simple_config.json')
+    loader = Loader(config_path)
+    actual = loader.logging_config()
+    assert actual == LOGGING_CONFIG


### PR DESCRIPTION
Closes #18.

It's not actually included in the fallback ini loader yet, but a future revision (#20) will fix that one way or another.