### PR TITLE
Allow ConfigLoaders to skip methods like app_config()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ unreleased
 * Reincorporate the test JSON config loader, active only during tests.
 * Remove the ``DEFAULT`` sentinal value; we'll use 'main' as the default loadable name, just like grandpa used to do. This is a breaking change.
 * Add logging config to the Montague Standard Format.
+* Allow config loaders to skip implementing ``app_config()`` and the like, instead of raising ``NotImplementedError``
 
 0.1.5 (2015-05-12)
 -----------------------------------------

--- a/src/montague/loadwsgi.py
+++ b/src/montague/loadwsgi.py
@@ -85,7 +85,7 @@ class Loader(object):
             if name is None:
                 name = 'main'
             return self.config_loader.app_config(name)
-        except NotImplementedError:
+        except (NotImplementedError, AttributeError):
             schemes = ['application', 'composite']
             app_config = self._fallback_config_loader(schemes, 'application', name)
             return app_config
@@ -184,7 +184,7 @@ class Loader(object):
             if name is None:
                 name = 'main'
             return self.config_loader.server_config(name)
-        except NotImplementedError:
+        except (NotImplementedError, AttributeError):
             schemes = ['server']
             server_config = self._fallback_config_loader(schemes, 'server', name)
             return server_config
@@ -208,7 +208,7 @@ class Loader(object):
             if name is None:
                 name = 'main'
             return self.config_loader.filter_config(name)
-        except NotImplementedError:
+        except (NotImplementedError, AttributeError):
             schemes = ['filter']
             filter_config = self._fallback_config_loader(schemes, 'filter', name)
             return filter_config
@@ -258,7 +258,7 @@ class Loader(object):
             name = 'main'
         try:
             return self.config_loader.logging_config(name)
-        except NotImplementedError:
+        except (NotImplementedError, AttributeError):
             return self.config['logging'][name]
 
 

--- a/src/montague/testjson.py
+++ b/src/montague/testjson.py
@@ -1,40 +1,15 @@
 from __future__ import absolute_import
 
 import json
-from montague.structs import LoadableConfig
 
 
 class JSONConfigLoader(object):
-    """This is a sample config loader. It uses a structural
-       convention that makes more sense for JSON; the root object
-       contains 'application' and 'server' keys, which each contain keys
-       for the respective items. It has basically no error handling
-       and is kind of inefficient."""
+    """This is the simplest possible config loader. It assumes
+       the JSON document is already in Montague Standard Format,
+       and that no adjustments or error checking is required."""
 
     def __init__(self, path):
         self.path = path
 
-    @property
-    def _config(self):
-        return json.load(open(self.path))
-
     def config(self):
-        return self._config
-
-    def app_config(self, name):
-        # Obviously this will throw a KeyError if the config isn't there.
-        # A real implementation would have error handling here.
-        config = self._config['application'][name]
-        return LoadableConfig.app(name=name, config=config, global_config={})
-
-    def server_config(self, name):
-        config = self._config['server'][name]
-        return LoadableConfig.server(name=name, config=config, global_config={})
-
-    def filter_config(self, name):
-        # Not covered in tests yet.
-        raise NotImplementedError
-
-    def logging_config(self, name):
-        # montague should be able to load it from the .config() property.
-        raise NotImplementedError
+        return json.load(open(self.path))

--- a/tests/test_ini_handling.py
+++ b/tests/test_ini_handling.py
@@ -51,6 +51,8 @@ def test_read_config():
                 'use': 'egg:montague_testapps#server_runner'
             },
         },
+        'logging': {
+        },
     }
     assert config.config() == expected
     assert Loader(ini_path).config == expected

--- a/tests/test_json_handling.py
+++ b/tests/test_json_handling.py
@@ -4,7 +4,7 @@ import pkg_resources
 import mock
 from montague.loadwsgi import Loader
 from montague import load_app, load_server
-import montague_testapps
+import montague_testapps.apps
 import montague.testjson
 
 here = os.path.dirname(__file__)


### PR DESCRIPTION
Instead of raising NotImplementedError, the config loaders can just not provide the methods at all.

Updated docstrings for the JSON test config loader, cleaned up the ini config loader.

Closes #20.