### PR TITLE
Validate proper config loader behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ unreleased
 * Remove the ``DEFAULT`` sentinal value; we'll use 'main' as the default loadable name, just like grandpa used to do. This is a breaking change.
 * Add logging config to the Montague Standard Format.
 * Allow config loaders to skip implementing ``app_config()`` and the like, instead of raising ``NotImplementedError``
+* Add validation functions to let config loaders test their compliance. These functions use assert statements, making them ideal for py.test, but they should work under unittest as well.
 
 0.1.5 (2015-05-12)
 -----------------------------------------

--- a/src/montague/__init__.py
+++ b/src/montague/__init__.py
@@ -18,3 +18,8 @@ def load_server(config_path, name=None):
 def load_filter(config_path, name=None):
     loader = Loader(config_path)
     return loader.load_filter(name)
+
+
+def load_logging_config(config_path, name=None):
+    loader = Loader(config_path)
+    return loader.logging_config(name)

--- a/src/montague/ini.py
+++ b/src/montague/ini.py
@@ -19,6 +19,7 @@ SCHEMEMAP = {
 }
 
 LOGGING_SECTIONS = ('loggers', 'handlers', 'formatters')
+MSF_KEYS = ('globals', 'application', 'composite', 'filter', 'server', 'logging')
 
 
 @attributes(['path'], apply_with_init=False, apply_immutable=True)
@@ -88,13 +89,15 @@ class IniConfigLoader(object):
                 filters[filter_name] = {'use': use_filter}
                 last_item['filter-with'] = filter_name
                 last_item = filters[filter_name]
-        config['logging'] = {}
         if all([self._parser.has_section(section_name) for section_name in LOGGING_SECTIONS]):
             loggers = convert_loggers(self._parser)
             handlers = convert_handlers(self._parser)
             formatters = convert_formatters(self._parser)
 
-            config['logging']['main'] = combine(loggers, handlers, formatters)
+            config['logging'] = {'main': combine(loggers, handlers, formatters)}
+
+        for key in MSF_KEYS:
+            config.setdefault(key, {})
         return config
 
     def config(self):

--- a/src/montague/validation.py
+++ b/src/montague/validation.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+import collections
+import types
+
+
+def validate_montague_standard_format(config):
+    for key in ('globals', 'application', 'composite', 'filter', 'server', 'logging'):
+        assert key in config
+        assert isinstance(config[key], collections.Mapping)
+
+
+def validate_config_loader_methods(config_loader):
+    assert hasattr(config_loader, 'config')
+    assert isinstance(config_loader.config, types.MethodType)
+    specific_methods_required = False
+    try:
+        result = config_loader.config()
+        validate_montague_standard_format(result)
+    except NotImplementedError:
+        # config loaders can fail to implement config() as long as they implement the other methods
+        specific_methods_required = True
+
+    for method in ('app_config', 'filter_config', 'server_config', 'logging_config'):
+        if specific_methods_required:
+            # If you don't implement .config(), you have to implement these
+            assert hasattr(config_loader, method)
+            assert isinstance(getattr(config_loader, method), types.MethodType)
+
+        # We don't know the names of actual apps/filters/etc to load, but we do know
+        # the loader shouldn't raise NotImplementedError if it has actually implemented them,
+        # so we can try that.
+        try:
+            getattr(config_loader, method)('__bogus__')
+        except NotImplementedError:
+            if specific_methods_required:
+                raise
+        except Exception:
+            # any other exception is fine here, because we don't know exactly what happens
+            # with a bogus name. usually KeyError, but maybe something else would be raised
+            pass

--- a/tests/config_files/simple_config.json
+++ b/tests/config_files/simple_config.json
@@ -1,4 +1,5 @@
 {
+    "globals": {},
     "application": {
         "main": {
             "use": "package:montague_testapps#basic_app"
@@ -11,6 +12,7 @@
             "filter-with": "filter"
         }
     },
+    "composite": {},
     "server": {
         "server_factory": {
             "use": "egg:montague_testapps#server_factory",

--- a/tests/test_ini_handling.py
+++ b/tests/test_ini_handling.py
@@ -3,8 +3,9 @@ import sys
 import pytest
 from montague.ini import IniConfigLoader
 from montague.loadwsgi import Loader
-from montague import load_app, load_server, load_filter
+from montague import load_app, load_server, load_filter, load_logging_config
 from montague.structs import ComposedFilter
+from montague.validation import validate_montague_standard_format, validate_config_loader_methods
 import montague_testapps
 
 here = os.path.dirname(__file__)
@@ -28,6 +29,7 @@ def test_read_config():
                 'use': 'package:montague_testapps#basic_app'
             },
         },
+        'composite': {},
         'filter': {
             'filter': {
                 'method_to_call': 'lower',
@@ -165,6 +167,12 @@ def test_logging_config():
         },
     }
     config_path = os.path.join(here, 'config_files/logging.ini')
-    loader = Loader(config_path)
-    actual = loader.logging_config()
+    actual = load_logging_config(config_path)
     assert actual == expected
+
+
+def test_validity():
+    config_path = os.path.join(here, 'config_files/simple_config.ini')
+    config_loader = IniConfigLoader(config_path)
+    validate_montague_standard_format(config_loader.config())
+    validate_config_loader_methods(config_loader)

--- a/tests/test_json_handling.py
+++ b/tests/test_json_handling.py
@@ -6,6 +6,7 @@ from montague.loadwsgi import Loader
 from montague import load_app, load_server
 import montague_testapps.apps
 import montague.testjson
+from montague.validation import validate_montague_standard_format, validate_config_loader_methods
 
 here = os.path.dirname(__file__)
 
@@ -64,6 +65,7 @@ LOGGING_CONFIG = {
 
 def test_read_config(working_set):
     expected = {
+        "globals": {},
         'application': {
             'main': {'use': 'package:montague_testapps#basic_app'},
             'egg': {'use': 'egg:montague_testapps#other'},
@@ -72,6 +74,7 @@ def test_read_config(working_set):
                 'use': 'package:montague_testapps#basic_app',
             },
         },
+        "composite": {},
         'filter': {
             'filter': {
                 'use': 'egg:montague_testapps#caps',
@@ -130,3 +133,10 @@ def test_load_logging_config(working_set):
     loader = Loader(config_path)
     actual = loader.logging_config()
     assert actual == LOGGING_CONFIG
+
+
+def test_validity(working_set):
+    loader = Loader(os.path.join(here, 'config_files/simple_config.json'))
+    config_loader = loader.config_loader
+    validate_montague_standard_format(config_loader.config())
+    validate_config_loader_methods(config_loader)


### PR DESCRIPTION
Adds a validation function to ensure a config dict is in Montague Standard format, and another one to ensure a config loader implements the appropriate methods.

Closes #23.