### PR TITLE
Properly detect final file extension.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 
 * Removed zope.interface requirement, since the interfaces themselves were removed in 0.2.0.
 * Removed useless console_script entry point.
+* Changed loader detection to only consider the final extension in a filename.
 
 0.2.0 (2015-06-14)
 -----------------------------------------

--- a/src/montague/loadwsgi.py
+++ b/src/montague/loadwsgi.py
@@ -47,7 +47,8 @@ class Loader(object):
 
     @staticmethod
     def _find_config_loader(config_path):
-        suffix = _get_suffix(config_path)
+        suffix = os.path.splitext(config_path)[1]  # returns ".ext"
+        suffix = suffix[1:]  # we just want "ext"
         entry_point_name = "montague.config_loader"
         eps = tuple(pkg_resources.iter_entry_points(entry_point_name, suffix))
         if len(eps) == 0:
@@ -260,8 +261,3 @@ class Loader(object):
             return self.config_loader.logging_config(name)
         except (NotImplementedError, AttributeError):
             return self.config['logging'][name]
-
-
-def _get_suffix(path):
-    basename = os.path.basename(path)
-    return ".".join(basename.split(".")[1:])

--- a/tests/config_files/multiple_extensions.test.sample.json
+++ b/tests/config_files/multiple_extensions.test.sample.json
@@ -1,0 +1,12 @@
+{
+    "globals": {},
+    "application": {
+        "main": {
+            "use": "package:montague_testapps#basic_app"
+        }
+    },
+    "composite": {},
+    "server": {},
+    "filter": {},
+    "logging": {}
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+import pkg_resources
+import mock
+import montague.testjson
+
+
+@pytest.yield_fixture(scope='function')
+def working_set():
+    # This is kind of a lot of work to go to just to get a dummy entry point.
+    # Also plenty of pkg_resources methods use the global working set with no
+    # way to override it.
+    # Better APIs for this would be very nice.
+    mock_ws = pkg_resources.WorkingSet()
+    dist = pkg_resources.get_distribution('montague')
+    mock_ep = pkg_resources.EntryPoint('json', 'montague.testjson', ['JSONConfigLoader'], dist=dist)
+    mock_dist = pkg_resources.Distribution(project_name='montague_testjson', version='1.0')
+    # There's some weird bug on Windows where if montague isn't installed
+    # in develop mode, having mock_dist use dist's location won't work.
+    mock_dist.location = montague.testjson.__file__
+    mock_dist._ep_map = {
+        'montague.config_loader': {
+            'json': mock_ep
+        }
+    }
+    mock_ws.add(mock_dist)
+    patcher = mock.patch.multiple(pkg_resources,
+                                  working_set=mock_ws,
+                                  iter_entry_points=mock_ws.iter_entry_points,
+                                  require=mock_ws.require)
+    patcher.start()
+    yield
+    patcher.stop()

--- a/tests/test_json_handling.py
+++ b/tests/test_json_handling.py
@@ -1,43 +1,10 @@
 import os
-import pytest
-import pkg_resources
-import mock
 from montague.loadwsgi import Loader
 from montague import load_app, load_server
 import montague_testapps.apps
-import montague.testjson
 from montague.validation import validate_montague_standard_format, validate_config_loader_methods
 
 here = os.path.dirname(__file__)
-
-
-@pytest.yield_fixture(scope='function')
-def working_set():
-    # This is kind of a lot of work to go to just to get a dummy entry point.
-    # Also plenty of pkg_resources methods use the global working set with no
-    # way to override it.
-    # Better APIs for this would be very nice.
-    mock_ws = pkg_resources.WorkingSet()
-    dist = pkg_resources.get_distribution('montague')
-    mock_ep = pkg_resources.EntryPoint('json', 'montague.testjson', ['JSONConfigLoader'], dist=dist)
-    mock_dist = pkg_resources.Distribution(project_name='montague_testjson', version='1.0')
-    # There's some weird bug on Windows where if montague isn't installed
-    # in develop mode, having mock_dist use dist's location won't work.
-    mock_dist.location = montague.testjson.__file__
-    mock_dist._ep_map = {
-        'montague.config_loader': {
-            'json': mock_ep
-        }
-    }
-    mock_ws.add(mock_dist)
-    patcher = mock.patch.multiple(pkg_resources,
-                                  working_set=mock_ws,
-                                  iter_entry_points=mock_ws.iter_entry_points,
-                                  require=mock_ws.require)
-    patcher.start()
-    yield
-    patcher.stop()
-
 
 LOGGING_CONFIG = {
     u'loggers': {

--- a/tests/test_loader_selection.py
+++ b/tests/test_loader_selection.py
@@ -1,0 +1,12 @@
+import os
+from montague.loadwsgi import Loader
+from montague.testjson import JSONConfigLoader
+
+here = os.path.dirname(__file__)
+
+
+def test_file_extensions(working_set):
+    loader = Loader(os.path.join(here, 'config_files/simple_config.json'))
+    assert isinstance(loader.config_loader, JSONConfigLoader)
+    loader = Loader(os.path.join(here, 'config_files/multiple_extensions.test.sample.json'))
+    assert isinstance(loader.config_loader, JSONConfigLoader)


### PR DESCRIPTION
A file named `foo.bar.baz` should use a loader for `baz`, not `bar.baz`.

Closes #31